### PR TITLE
Fix parsing of Git version numbers

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -162,7 +162,7 @@ clone() {
   You should add files to your new repository."
 		exit
 	fi
-	GIT_VERSION_MAJOR=$(git --version | sed -n 's/.* \([0-9]\)\..*/\1/p' )
+	GIT_VERSION_MAJOR=$(git --version | sed -n 's/.* \([0-9]\+\)\..*/\1/p' )
 	if [ 1 -lt "$GIT_VERSION_MAJOR" ];then
 		git fetch origin "$VCSH_BRANCH"
 	else
@@ -477,8 +477,8 @@ write_gitignore() {
 	use
 	cd "$VCSH_BASE" || fatal "could not enter '$VCSH_BASE'" 11
 	local GIT_VERSION="$(git --version)"
-	local GIT_VERSION_MAJOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\)\..*/\1/p')
-	local GIT_VERSION_MINOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\)\.\([0-9]\)\..*/\2/p')
+	local GIT_VERSION_MAJOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\+\)\..*/\1/p')
+	local GIT_VERSION_MINOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\+\)\.\([0-9]\+\)\..*/\2/p')
 	OLDIFS=$IFS
 	IFS=$(printf '\n\t')
 	gitignores=$(for file in $(git ls-files); do


### PR DESCRIPTION
The Git minor version now has two digits, so fix the regexp parsing it.
We'll also anticipate the future and handle the time when the major
version hits 10 and parse accordingly

Signed-off-by: martin f. krafft <madduck@madduck.net>